### PR TITLE
Adjust CompileInput output extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 Suite of Funz commands ``fz*`:
 
-* `fzc`: compile input files (almost like `Funz CompileInput ...`)
+* `fzc`: compile input files (almost like `Funz CompileInput ...`). Output files
+  keep the same extension as the source (e.g. `sample.pij` -> `sample_X=1.pij`).
 * `fzp`: parse output files (almost like `Funz ParseResults ...`)
 * `fzr`: run input files (almost like `Funz Run ...`)
 * `fzd`: apply design/algorithm on command (almost like `Funz Design ...`)

--- a/fz.py
+++ b/fz.py
@@ -99,9 +99,10 @@ class fz:
                         scenario_dict[k] = group_combo[i]
                     combos.append(scenario_dict)
 
+        basename = os.path.basename(input_file)
+        output_prefix_from_file, ext = os.path.splitext(basename)
         if output_prefix is None:
-            basename = os.path.basename(input_file)
-            output_prefix = os.path.splitext(basename)[0]
+            output_prefix = output_prefix_from_file
 
         for scenario_dict in combos:
             # 1) Utilisation directe du texte
@@ -133,9 +134,9 @@ class fz:
 
             scenario_suffix = "_".join(f"{k}={scenario_dict[k]}" for k in suffix_keys)
             if scenario_suffix:
-                fname = f"{output_prefix}_{scenario_suffix}.pij"
+                fname = f"{output_prefix}_{scenario_suffix}{ext}"
             else:
-                fname = f"{output_prefix}.pij"
+                fname = f"{output_prefix}{ext}"
 
             out_filename = os.path.join(dir_path, fname)
 


### PR DESCRIPTION
## Summary
- keep the input file's extension when compiling inputs
- mention this behaviour in the README

## Testing
- `python3 -m py_compile fz.py`

------
https://chatgpt.com/codex/tasks/task_e_685b0a61b4e08327ac030dce48e6f877