### PR TITLE
Update docs with filename template example

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Suite of Funz commands ``fz*`:
   datasets is written to the same directory as the input file.
   File names can be customized with the ``filename_template`` option of
   ``CompileInput``.
+  Example:
+    CompileInput(..., filename_template="{prefix}_R{r0:.0f}{ext}")
 * `fzp`: parse output files (almost like `Funz ParseResults ...`)
 * `fzr`: run input files (almost like `Funz Run ...`)
 * `fzd`: apply design/algorithm on command (almost like `Funz Design ...`)

--- a/fz.py
+++ b/fz.py
@@ -54,6 +54,7 @@ class fz:
         - filename_template : gabarit ``str.format`` pour nommer les fichiers.
           Les clés disponibles sont ``prefix``, ``ext``, ``scenario`` et les
           noms de variables.
+            Exemple d'appel : f.CompileInput(..., filename_template="{prefix}_R{r0:.0f}{ext}") pour formater r0 en entier.
         - use_dirs : si True, crée une arborescence de répertoires basée sur
           les valeurs des variables non groupées. Les dossiers sont classés
           par variable en commençant par celles ayant le moins de valeurs


### PR DESCRIPTION
## Summary
- show how to customize filenames in README
- document integer formatting use in `CompileInput`

## Testing
- `python3 -m py_compile fz.py`

------
https://chatgpt.com/codex/tasks/task_e_685d5d13d00c83278a96d88f6599ff4e