### PR TITLE
Improve filename template error handling

### DIFF
--- a/fz.py
+++ b/fz.py
@@ -155,7 +155,12 @@ class fz:
                     "scenario": scenario_suffix,
                     **scenario_dict,
                 }
-                fname = filename_template.format(**format_vars)
+                try:
+                    fname = filename_template.format(**format_vars)
+                except KeyError as e:
+                    raise ValueError(
+                        f"Unknown variable in filename_template: {e.args[0]}"
+                    )
 
             out_filename = os.path.join(dir_path, fname)
 

--- a/tests/test_filename_template_error.py
+++ b/tests/test_filename_template_error.py
@@ -1,0 +1,30 @@
+import sys
+import types
+import pytest
+
+# create mock rpy2 with minimal API
+module = types.ModuleType("rpy2")
+class DummyR:
+    def assign(self, name, val):
+        pass
+    def __call__(self, code):
+        return [0]
+robjects = types.SimpleNamespace(r=DummyR())
+module.robjects = robjects
+sys.modules['rpy2'] = module
+sys.modules['rpy2.robjects'] = robjects
+
+from fz import fz
+
+
+def test_unknown_placeholder_in_filename_template(tmp_path):
+    input_file = tmp_path / "in.txt"
+    input_file.write_text("simple")
+    f = fz()
+    with pytest.raises(ValueError, match="Unknown variable in filename_template: unknown"):
+        f.CompileInput(
+            input_file=str(input_file),
+            input_variables={"x": [1]},
+            filename_template="{prefix}_{unknown}{ext}"
+        )
+


### PR DESCRIPTION
## Summary
- raise a `ValueError` when `CompileInput` filename templates refer to unknown variables
- test error handling for unknown placeholders in filename templates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d5eaa9dc48327b0f3c89677769c2d