### PR TITLE
Handle integer fallback in formatted expressions

### DIFF
--- a/fz.py
+++ b/fz.py
@@ -235,11 +235,14 @@ class fz:
 
     def _fallback_to_python_format(self, fallback_str):
         """
-        Interprète fallback_str comme ex. 
+        Interprète fallback_str comme ex.
+          "0"         => .0f  (format entier)
           "0.00"       => .2f  (2 décimales en notation fixe)
           "0.0000"     => .4f  (4 décimales en notation fixe)
           "0.0000E00"  => .4E  (4 décimales en notation scientifique)
         """
+        if fallback_str == "0":
+            return ".0f"
         m_decimal = re.match(r'^0\.(0+)$', fallback_str)
         if m_decimal:
             count_zero = len(m_decimal.group(1))

--- a/tests/test_integer_fallback.py
+++ b/tests/test_integer_fallback.py
@@ -1,0 +1,24 @@
+import sys
+import types
+
+# create mock rpy2 with minimal API
+module = types.ModuleType("rpy2")
+class DummyR:
+    def assign(self, name, val):
+        pass
+    def __call__(self, code):
+        return [42.3]
+robjects = types.SimpleNamespace(r=DummyR())
+module.robjects = robjects
+sys.modules['rpy2'] = module
+sys.modules['rpy2.robjects'] = robjects
+
+
+def test_integer_format_with_zero_fallback():
+    import importlib
+    import fz as fz_module
+    importlib.reload(fz_module)
+    f = fz_module.fz()
+    output = f._parse_and_replace_at_braces_format("value @{expr|0}")
+    assert output == "value 42"
+


### PR DESCRIPTION
## Summary
- support integer formatting when `@{expr | 0}` is used
- add regression test for zero fallback formatting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d66f5df2883278edaec0ec8c55c77