### PR TITLE
Track scenarios in CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@ Suite of Funz commands ``fz*`:
 * `fzc`: compile input files (almost like `Funz CompileInput ...`). Output files
   keep the same extension as the source (e.g. `sample.pij` -> `sample_X=1.pij`).
   A file ``generated_files.txt`` listing the relative paths of all generated
-  datasets is written to the same directory as the input file.
+  datasets is written to the same directory as the input file. A second file
+  ``generated_files.csv`` stores the same information along with all scenario
+  variable values for easier inspection.
   File names can be customized with the ``filename_template`` option of
   ``CompileInput``.
   Example:

--- a/fz.py
+++ b/fz.py
@@ -69,6 +69,7 @@ class fz:
         group_vars = list(group_variables) if group_variables else []
         input_dir = os.path.dirname(os.path.abspath(input_file)) or "."
         generated_files = []
+        scenario_infos = []
 
                 # Détermination de l'ordre des variables non groupées
         if use_dirs:
@@ -168,12 +169,25 @@ class fz:
                 f.write(final_text)
 
             print(f"Generated : {out_filename} with {scenario_dict}")
-            generated_files.append(os.path.relpath(out_filename, start=input_dir))
+            rel_path = os.path.relpath(out_filename, start=input_dir)
+            generated_files.append(rel_path)
+            scenario_infos.append({"file": rel_path, **scenario_dict})
 
         list_file = os.path.join(input_dir, "generated_files.txt")
         with open(list_file, "w", encoding="utf-8") as lf:
             lf.write("\n".join(generated_files))
         print(f"List of generated files written to {list_file}")
+
+        # Write detailed scenario information to CSV
+        if scenario_infos:
+            csv_file = os.path.join(input_dir, "generated_files.csv")
+            var_names = sorted({k for d in scenario_infos for k in d.keys() if k != "file"})
+            with open(csv_file, "w", encoding="utf-8", newline="") as cf:
+                cf.write("file," + ",".join(var_names) + "\n")
+                for info in scenario_infos:
+                    row = [info.get(var, "") for var in var_names]
+                    cf.write(",".join([info["file"]] + [str(x) for x in row]) + "\n")
+            print(f"Detailed scenario info written to {csv_file}")
 
     # --------------------------------------------------------------------------
     # Méthodes "privées"

--- a/tests/test_generated_files_csv.py
+++ b/tests/test_generated_files_csv.py
@@ -1,0 +1,31 @@
+import sys
+import types
+import csv
+
+module = types.ModuleType("rpy2")
+class DummyR:
+    def assign(self, name, val):
+        pass
+    def __call__(self, code):
+        return [0]
+robjects = types.SimpleNamespace(r=DummyR())
+module.robjects = robjects
+sys.modules['rpy2'] = module
+sys.modules['rpy2.robjects'] = robjects
+
+from fz import fz
+
+
+def test_generated_files_csv(tmp_path):
+    input_file = tmp_path / "in.txt"
+    input_file.write_text("simple")
+    f = fz()
+    f.CompileInput(str(input_file), input_variables={"x": [1, 2]})
+
+    csv_path = tmp_path / "generated_files.csv"
+    assert csv_path.exists()
+    with open(csv_path, newline="") as cf:
+        rows = list(csv.DictReader(cf))
+    assert len(rows) == 2
+    assert rows[0]["x"] == "1"
+    assert rows[1]["x"] == "2"


### PR DESCRIPTION
## Summary
- store scenario info during file generation
- output `generated_files.csv` with scenarios alongside the text list
- mention CSV tracking file in README
- add test covering CSV generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68624f2aef3c832797b15a8d8268fefe