### PR TITLE
Add path column to generated_files.csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@ Suite of Funz commands ``fz*`:
 
 * `fzc`: compile input files (almost like `Funz CompileInput ...`). Output files
   keep the same extension as the source (e.g. `sample.pij` -> `sample_X=1.pij`).
-  A file ``generated_files.csv`` lists the relative paths of all generated
-  datasets along with their scenario variable values for easier inspection.
+  A file ``generated_files.csv`` lists, for each generated dataset, the
+  directory ``path`` and the ``file`` name along with the scenario variable
+  values for easier inspection.
   File names can be customized with the ``filename_template`` option of
   ``CompileInput``.
   Example:

--- a/fz.py
+++ b/fz.py
@@ -62,8 +62,9 @@ class fz:
           sont alors placés dans ces répertoires et ne contiennent plus ces
           variables dans leur nom
         - À la fin de l'exécution, un fichier ``generated_files.csv`` listant
-          les chemins relatifs et les valeurs de variables de chaque scénario
-          est sauvegardé dans le répertoire du fichier d'entrée
+          pour chaque scénario le chemin (``path``) et le nom de fichier
+          (``file``) ainsi que les valeurs de variables est sauvegardé dans le
+          répertoire du fichier d'entrée
         """
         template_text = self._load_jdd(input_file)
         group_vars = list(group_variables) if group_variables else []
@@ -169,28 +170,21 @@ class fz:
 
             print(f"Generated : {out_filename} with {scenario_dict}")
             rel_path = os.path.relpath(out_filename, start=input_dir)
-            scenario_infos.append({"file": rel_path, **scenario_dict})
+            scenario_infos.append({
+                "path": os.path.dirname(rel_path) or ".",
+                "file": os.path.basename(rel_path),
+                **scenario_dict,
+            })
 
         # Write detailed scenario information to CSV
         if scenario_infos:
             csv_file = os.path.join(input_dir, "generated_files.csv")
-            var_names = sorted({k for d in scenario_infos for k in d.keys() if k != "file"})
+            var_names = sorted({k for d in scenario_infos for k in d.keys() if k not in {"path", "file"}})
             with open(csv_file, "w", encoding="utf-8", newline="") as cf:
-                cf.write("file," + ",".join(var_names) + "\n")
+                cf.write("path,file," + ",".join(var_names) + "\n")
                 for info in scenario_infos:
                     row = [info.get(var, "") for var in var_names]
-                    cf.write(",".join([info["file"]] + [str(x) for x in row]) + "\n")
-            print(f"Detailed scenario info written to {csv_file}")
-
-        # Write detailed scenario information to CSV
-        if scenario_infos:
-            csv_file = os.path.join(input_dir, "generated_files.csv")
-            var_names = sorted({k for d in scenario_infos for k in d.keys() if k != "file"})
-            with open(csv_file, "w", encoding="utf-8", newline="") as cf:
-                cf.write("file," + ",".join(var_names) + "\n")
-                for info in scenario_infos:
-                    row = [info.get(var, "") for var in var_names]
-                    cf.write(",".join([info["file"]] + [str(x) for x in row]) + "\n")
+                    cf.write(",".join([info["path"], info["file"]] + [str(x) for x in row]) + "\n")
             print(f"Detailed scenario info written to {csv_file}")
 
     # --------------------------------------------------------------------------

--- a/tests/test_generated_files_csv.py
+++ b/tests/test_generated_files_csv.py
@@ -1,6 +1,7 @@
 import sys
 import types
 import csv
+import os
 
 module = types.ModuleType("rpy2")
 class DummyR:
@@ -27,5 +28,10 @@ def test_generated_files_csv(tmp_path):
     with open(csv_path, newline="") as cf:
         rows = list(csv.DictReader(cf))
     assert len(rows) == 2
+    expected_path = os.path.relpath(os.getcwd(), start=tmp_path)
+    assert rows[0]["path"] == expected_path
+    assert rows[0]["file"].endswith("in_x=1.txt")
     assert rows[0]["x"] == "1"
+    assert rows[1]["path"] == expected_path
+    assert rows[1]["file"].endswith("in_x=2.txt")
     assert rows[1]["x"] == "2"


### PR DESCRIPTION
## Summary
- include directory path separately from filename in generated CSV
- document new columns
- update tests for the new CSV format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686525ee22dc8327b21ac514698c175f